### PR TITLE
Remove custom WSL2 kernel?

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -76,7 +76,6 @@ runs:
         sudo rm -rf submodules/wireguard-go
         sudo rm -rf submodules/wireguard-tools
         sudo rm -rf submodules/wireguard-windows
-        sudo rm -rf submodules/WSL2-Linux-Kernel
 
     # https://github.com/actions/download-artifact/tree/v4/?tab=readme-ov-file#limitations
     - shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -36,15 +36,6 @@ runs:
     - run: sudo apt-get install mingw-w64 imagemagick libarchive-tools build-essential flex bison dwarves libssl-dev libelf-dev bc ccache librsvg2-bin fakeroot debhelper libtool-bin cmake -y
       shell: bash
 
-    # Setup ccache for wsl2-linux-kernel
-    - name: "Setup ccache"
-      uses: actions/cache@v4
-      with:
-        path: /home/runner/.cache/ccache
-        key: wsl2-linux-kernel-ccache-${{ hashFiles('patches/WSL2-linux-kernel.patch') }}
-        restore-keys: |
-          wsl2-linux-kernel-ccache-
-
     # Setup wireguard windows dist cache
     - name: "Setup wireguard windows dist cache"
       uses: actions/cache@v4

--- a/.github/actions/windows-wsl2/action.yml
+++ b/.github/actions/windows-wsl2/action.yml
@@ -29,12 +29,6 @@ runs:
       run: wsl --import Ubuntu22.04 . jammy-server-cloudimg-amd64-root.tar.xz --version 2
     - shell: pwsh
       run: wsl --list --verbose
-    # - shell: pwsh
-    #   run: wsl --shutdown
-    # - shell: pwsh
-    #   run: Copy-Item "D:\a\the-wireguard-effect\the-wireguard-effect\submodules\.wslconfig" -Destination "C:\Users\runneradmin"
-    # - shell: pwsh
-    #   run: sleep 15
 
     # Install dependencies
     - shell: pwsh

--- a/.github/actions/windows-wsl2/action.yml
+++ b/.github/actions/windows-wsl2/action.yml
@@ -29,12 +29,12 @@ runs:
       run: wsl --import Ubuntu22.04 . jammy-server-cloudimg-amd64-root.tar.xz --version 2
     - shell: pwsh
       run: wsl --list --verbose
-    - shell: pwsh
-      run: wsl --shutdown
-    - shell: pwsh
-      run: Copy-Item "D:\a\the-wireguard-effect\the-wireguard-effect\submodules\.wslconfig" -Destination "C:\Users\runneradmin"
-    - shell: pwsh
-      run: sleep 15
+    # - shell: pwsh
+    #   run: wsl --shutdown
+    # - shell: pwsh
+    #   run: Copy-Item "D:\a\the-wireguard-effect\the-wireguard-effect\submodules\.wslconfig" -Destination "C:\Users\runneradmin"
+    # - shell: pwsh
+    #   run: sleep 15
 
     # Install dependencies
     - shell: pwsh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,14 +47,6 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install mingw-w64 imagemagick libarchive-tools build-essential flex bison dwarves libssl-dev libelf-dev bc ccache librsvg2-bin fakeroot debhelper libtool-bin cmake -y
 
-      - name: "Setup ccache"
-        uses: actions/cache@v4
-        with:
-          path: /home/runner/.cache/ccache
-          key: wsl2-linux-kernel-ccache-${{ hashFiles('patches/WSL2-linux-kernel.patch') }}
-          restore-keys: |
-            wsl2-linux-kernel-ccache-
-
       - name: "Setup wireguard windows dist cache"
         uses: actions/cache@v4
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,10 +10,6 @@
 [submodule "submodules/wireguard-apple"]
 	path = submodules/wireguard-apple
 	url = https://github.com/WireGuard/wireguard-apple.git
-[submodule "submodules/WSL2-Linux-Kernel"]
-	path = submodules/WSL2-Linux-Kernel
-	url = https://github.com/microsoft/WSL2-Linux-Kernel.git
-	branch = linux-msft-wsl-6.6.y
 [submodule "submodules/nvlist"]
 	path = submodules/nvlist
 	url = https://github.com/fudosecurity/nvlist.git

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,7 +74,6 @@
         "submodules/wireguard-apple/**": true,
         "submodules/wireguard-go/**": true,
         "submodules/wireguard-tools/**": true,
-        "submodules/wireguard-windows/**": true,
-        "submodules/WSL2-Linux-Kernel/**": true
+        "submodules/wireguard-windows/**": true
     }
 }

--- a/submodules/.wslconfig
+++ b/submodules/.wslconfig
@@ -1,5 +1,0 @@
-# https://learn.microsoft.com/en-us/windows/wsl/wsl-config#wslconf
-[wsl2]
-
-# Specify a custom Linux kernel to use with your installed distros.
-kernel=D:\\a\\the-wireguard-effect\\the-wireguard-effect\\dist\\prebuilds\\win32-amd64-wsl2-linux-kernel-bzImage

--- a/submodules/build.bash
+++ b/submodules/build.bash
@@ -26,8 +26,8 @@ sudo ldconfig
 (cd ./nvlist && git reset --hard && git clean --force -d)
 
 # osxcross for cross compiling wg to darwin
-(cd ./osxcross/tarballs && wget -nc https://s3.dockerproject.org/darwin/v2/MacOSX10.10.sdk.tar.xz)
-(cd ./osxcross && sudo UNATTENDED=1 TARGET_DIR=/usr/local/osxcross ./build.sh)
+# (cd ./osxcross/tarballs && wget -nc https://s3.dockerproject.org/darwin/v2/MacOSX10.10.sdk.tar.xz)
+# (cd ./osxcross && sudo UNATTENDED=1 TARGET_DIR=/usr/local/osxcross ./build.sh)
 
 # wg-quick prebuilds
 (cd ./wireguard-tools/src && make clean && PLATFORM=linux make && cp ./wg ../../../dist/prebuilds/linux-wg && chmod +x ../../../dist/prebuilds/linux-wg)
@@ -40,11 +40,15 @@ sudo ldconfig
 (cd ./wireguard-windows && unset GOROOT && make clean && make amd64/wireguard.exe && cp amd64/wireguard.exe ../../dist/prebuilds/win32-amd64-wireguard.exe)
 
 # Windows WSL2 modified linux kernel (https://github.com/microsoft/WSL/issues/7547)
-(cd ./WSL2-Linux-Kernel && git apply ../../patches/WSL2-linux-kernel.patch)
-(cd ./WSL2-Linux-Kernel && make -j $(nproc) KCONFIG_CONFIG=Microsoft/config-wsl CC="ccache gcc")
-(cd ./WSL2-Linux-Kernel && cp arch/x86/boot/bzImage ../../dist/prebuilds/win32-amd64-wsl2-linux-kernel-bzImage)
-(cd ./WSL2-Linux-Kernel && rm -f Microsoft/*.old)
-(cd ./WSL2-Linux-Kernel && git reset --hard)
+# (cd ./WSL2-Linux-Kernel && make -j $(nproc) KCONFIG_CONFIG=Microsoft/config-wsl CC="ccache gcc")
+# (cd ./WSL2-Linux-Kernel && cp arch/x86/boot/bzImage ../../dist/prebuilds/win32-amd64-wsl2-linux-kernel-bzImage-not-patched)
+# (cd ./WSL2-Linux-Kernel && rm -f Microsoft/*.old)
+# (cd ./WSL2-Linux-Kernel && git reset --hard)
+# (cd ./WSL2-Linux-Kernel && git apply ../../patches/WSL2-linux-kernel.patch)
+# (cd ./WSL2-Linux-Kernel && make -j $(nproc) KCONFIG_CONFIG=Microsoft/config-wsl CC="ccache gcc")
+# (cd ./WSL2-Linux-Kernel && cp arch/x86/boot/bzImage ../../dist/prebuilds/win32-amd64-wsl2-linux-kernel-bzImage)
+# (cd ./WSL2-Linux-Kernel && rm -f Microsoft/*.old)
+# (cd ./WSL2-Linux-Kernel && git reset --hard)
 
 # Symlink prebuilds
 (cd ../src && ln -s ../dist/prebuilds/* .)

--- a/submodules/build.bash
+++ b/submodules/build.bash
@@ -26,8 +26,8 @@ sudo ldconfig
 (cd ./nvlist && git reset --hard && git clean --force -d)
 
 # osxcross for cross compiling wg to darwin
-# (cd ./osxcross/tarballs && wget -nc https://s3.dockerproject.org/darwin/v2/MacOSX10.10.sdk.tar.xz)
-# (cd ./osxcross && sudo UNATTENDED=1 TARGET_DIR=/usr/local/osxcross ./build.sh)
+(cd ./osxcross/tarballs && wget -nc https://s3.dockerproject.org/darwin/v2/MacOSX10.10.sdk.tar.xz)
+(cd ./osxcross && sudo UNATTENDED=1 TARGET_DIR=/usr/local/osxcross ./build.sh)
 
 # wg-quick prebuilds
 (cd ./wireguard-tools/src && make clean && PLATFORM=linux make && cp ./wg ../../../dist/prebuilds/linux-wg && chmod +x ../../../dist/prebuilds/linux-wg)
@@ -38,17 +38,6 @@ sudo ldconfig
 
 # Wireguard-windows prebuilds
 (cd ./wireguard-windows && unset GOROOT && make clean && make amd64/wireguard.exe && cp amd64/wireguard.exe ../../dist/prebuilds/win32-amd64-wireguard.exe)
-
-# Windows WSL2 modified linux kernel (https://github.com/microsoft/WSL/issues/7547)
-# (cd ./WSL2-Linux-Kernel && make -j $(nproc) KCONFIG_CONFIG=Microsoft/config-wsl CC="ccache gcc")
-# (cd ./WSL2-Linux-Kernel && cp arch/x86/boot/bzImage ../../dist/prebuilds/win32-amd64-wsl2-linux-kernel-bzImage-not-patched)
-# (cd ./WSL2-Linux-Kernel && rm -f Microsoft/*.old)
-# (cd ./WSL2-Linux-Kernel && git reset --hard)
-# (cd ./WSL2-Linux-Kernel && git apply ../../patches/WSL2-linux-kernel.patch)
-# (cd ./WSL2-Linux-Kernel && make -j $(nproc) KCONFIG_CONFIG=Microsoft/config-wsl CC="ccache gcc")
-# (cd ./WSL2-Linux-Kernel && cp arch/x86/boot/bzImage ../../dist/prebuilds/win32-amd64-wsl2-linux-kernel-bzImage)
-# (cd ./WSL2-Linux-Kernel && rm -f Microsoft/*.old)
-# (cd ./WSL2-Linux-Kernel && git reset --hard)
 
 # Symlink prebuilds
 (cd ../src && ln -s ../dist/prebuilds/* .)


### PR DESCRIPTION
after updating from [linux-msft-wsl-5.15.y](https://github.com/microsoft/WSL2-Linux-Kernel/tree/linux-msft-wsl-5.15.y) to [linux-msft-wsl-6.6.y](https://github.com/microsoft/WSL2-Linux-Kernel) it appears it is no longer necessary to patch the kernel for wireguard support.