### PR TITLE
Upgrade to TypeScript 7 and @effect/tsgo

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "lint-fix": "oxlint --disable-nested-config --fix && oxfmt --write !repos/** !submodules/**",
         "changeset-version": "changeset version",
         "changeset-publish": "pnpm build && changeset publish",
-        "prepare": "effect-language-service patch"
+        "prepare": "effect-tsgo patch"
     },
     "dependencies": {
         "effect-schemas": "0.0.19",
@@ -83,8 +83,8 @@
         "@changesets/cli": "2.31.1",
         "@effect/build-utils": "0.8.9",
         "@effect/docgen": "4.0.0-beta.102",
-        "@effect/language-service": "0.87.1",
         "@effect/platform-node": "4.0.0-beta.102",
+        "@effect/tsgo": "0.32.0",
         "@effect/vitest": "4.0.0-beta.102",
         "@types/ini": "4.1.1",
         "@types/node": "25.9.5",
@@ -100,7 +100,7 @@
         "oxlint": "1.76.0",
         "rimraf": "6.1.3",
         "tsx": "4.23.5",
-        "typescript": "6.0.3",
+        "typescript": "7.0.2",
         "vite": "8.2.0",
         "vitest": "4.1.10"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@effect/docgen>typescript': 6.0.3
-  madge>typescript: 6.0.3
+  '@effect/docgen>typescript': 7.0.2
+  madge>typescript: 7.0.2
 
 importers:
 
@@ -39,13 +39,13 @@ importers:
         version: 0.8.9
       '@effect/docgen':
         specifier: 4.0.0-beta.102
-        version: 4.0.0-beta.102(ioredis@5.11.1)(tsx@4.23.5)(typescript@6.0.3)
-      '@effect/language-service':
-        specifier: 0.87.1
-        version: 0.87.1
+        version: 4.0.0-beta.102(ioredis@5.11.1)(tsx@4.23.5)(typescript@7.0.2)
       '@effect/platform-node':
         specifier: 4.0.0-beta.102
         version: 4.0.0-beta.102(effect@4.0.0-beta.102)(ioredis@5.11.1)
+      '@effect/tsgo':
+        specifier: 0.32.0
+        version: 0.32.0
       '@effect/vitest':
         specifier: 4.0.0-beta.102
         version: 4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.10)
@@ -78,7 +78,7 @@ importers:
         version: 5.11.1
       madge:
         specifier: 8.0.0
-        version: 8.0.0(typescript@6.0.3)
+        version: 8.0.0(typescript@7.0.2)
       oxfmt:
         specifier: 0.61.0
         version: 0.61.0
@@ -92,8 +92,8 @@ importers:
         specifier: 4.23.5
         version: 4.23.5
       typescript:
-        specifier: 6.0.3
-        version: 6.0.3
+        specifier: 7.0.2
+        version: 7.0.2
       vite:
         specifier: 8.2.0
         version: 8.2.0(@types/node@25.9.5)(tsx@4.23.5)
@@ -275,11 +275,7 @@ packages:
     hasBin: true
     peerDependencies:
       tsx: '>=4.19.3 <5.0.0'
-      typescript: 6.0.3
-
-  '@effect/language-service@0.87.1':
-    resolution: {integrity: sha512-kcljlJmEgqg5mFAM6UShJYJjMqJb3TbHHxrK8Qoubvwugc0aVWpRkbdgQvK5b17puOt3BKXXKOmcV+oQt0oQqQ==}
-    hasBin: true
+      typescript: 7.0.2
 
   '@effect/markdown-toc@0.1.0':
     resolution: {integrity: sha512-IRfvvwqQLabVTIw9hhIj4scOGIYPfa13QuEFv+dBWE6p47R+RR0J8jQvfDINFf0Vn80XXVjNRtZxkZpkKXLx2A==}
@@ -298,6 +294,45 @@ packages:
     peerDependencies:
       effect: ^4.0.0-beta.102
       ioredis: ^5.7.0
+
+  '@effect/tsgo-darwin-arm64@0.32.0':
+    resolution: {integrity: sha512-Fk73FoWgCsVOLjQRtHU9dsveQb+PuX9y+mo4A5ZjzQYh4ax4+W/6EdpLin78b6ypGXqlZUWlVMzofDZVHNgdNg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@effect/tsgo-darwin-x64@0.32.0':
+    resolution: {integrity: sha512-BQ37bEuff1zibLGXNxwaQ7wxYcRPoHAG2XGsj8/dQoyaSSjQ+i6k+kc5JdDfa2lDCOKZ+E/sz3/7ChHAZlVQig==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@effect/tsgo-linux-arm64@0.32.0':
+    resolution: {integrity: sha512-sYfBUITLT7wveHSidwCqqFfADx4ropTCOmRIqdmJe+uEJQ09ClWJ8sMWpPeEcyHfjokHTOcH8E7xLxpyEQ7Bgg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@effect/tsgo-linux-arm@0.32.0':
+    resolution: {integrity: sha512-EbhO5HNNLvhXCilVPSUWqfAlb4l35OfFQqeRA6r+IvTLgeHHRdGw+1qSj2j1uWj7pHAjCNya9r9U80E/hdTAJA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@effect/tsgo-linux-x64@0.32.0':
+    resolution: {integrity: sha512-ZfchMTnGKH+ZPHa1le+iyMJPUwQMMpmUAxV5F8Dw9aksBqTSUWrMrA4UA1VQXbKX2VRaEMa1BGsdL02sPAl6Ug==}
+    cpu: [x64]
+    os: [linux]
+
+  '@effect/tsgo-win32-arm64@0.32.0':
+    resolution: {integrity: sha512-Ra9c9EZiXohVZvNfy3GjXvqhovFPclDdl4GxwSxi2vwiuCokDGga4N2ua6TmJRb7+opD2QMucp7LDXYoTR7lyQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@effect/tsgo-win32-x64@0.32.0':
+    resolution: {integrity: sha512-70QjkzRcCzezq1JaTESAYSOe2Z6dAgEOwmHIOtSRxIeEg24wTeUsPr5N1Q46XovHsiuhydyWxhWBokXDFlzB3g==}
+    cpu: [x64]
+    os: [win32]
+
+  '@effect/tsgo@0.32.0':
+    resolution: {integrity: sha512-UyJn4g53NaM47HOcAf9WvtMkXmaX9WddLg8Nqg9NItJLH/9e6LfSAmXpFuluT0gApqev8DKOCtU9Ib9Ol/3QuA==}
+    hasBin: true
 
   '@effect/vitest@4.0.0-beta.102':
     resolution: {integrity: sha512-4dipFAYG6imOzrY3zy3BgzCJkbb9xESyzUef0WSx8bsK0/SpITqbJpdwKeOyDWLZ+rimjua8IbTFMAde865pIQ==}
@@ -971,6 +1006,126 @@ packages:
   '@typescript-eslint/visitor-keys@8.65.0':
     resolution: {integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
@@ -1789,7 +1944,7 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -2371,9 +2526,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   undici-types@7.24.6:
@@ -2818,7 +2973,7 @@ snapshots:
       micromatch: 4.0.8
       pkg-entry-points: 1.1.2
 
-  '@effect/docgen@4.0.0-beta.102(ioredis@5.11.1)(tsx@4.23.5)(typescript@6.0.3)':
+  '@effect/docgen@4.0.0-beta.102(ioredis@5.11.1)(tsx@4.23.5)(typescript@7.0.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@effect/markdown-toc': 0.1.0
@@ -2829,15 +2984,13 @@ snapshots:
       glob: 13.0.6
       prettier: 3.9.6
       ts-morph: 27.0.2
-      tsconfck: 3.1.6(typescript@6.0.3)
+      tsconfck: 3.1.6(typescript@7.0.2)
       tsx: 4.23.5
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - bufferutil
       - ioredis
       - utf-8-validate
-
-  '@effect/language-service@0.87.1': {}
 
   '@effect/markdown-toc@0.1.0':
     dependencies:
@@ -2873,6 +3026,37 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@effect/tsgo-darwin-arm64@0.32.0':
+    optional: true
+
+  '@effect/tsgo-darwin-x64@0.32.0':
+    optional: true
+
+  '@effect/tsgo-linux-arm64@0.32.0':
+    optional: true
+
+  '@effect/tsgo-linux-arm@0.32.0':
+    optional: true
+
+  '@effect/tsgo-linux-x64@0.32.0':
+    optional: true
+
+  '@effect/tsgo-win32-arm64@0.32.0':
+    optional: true
+
+  '@effect/tsgo-win32-x64@0.32.0':
+    optional: true
+
+  '@effect/tsgo@0.32.0':
+    optionalDependencies:
+      '@effect/tsgo-darwin-arm64': 0.32.0
+      '@effect/tsgo-darwin-x64': 0.32.0
+      '@effect/tsgo-linux-arm': 0.32.0
+      '@effect/tsgo-linux-arm64': 0.32.0
+      '@effect/tsgo-linux-x64': 0.32.0
+      '@effect/tsgo-win32-arm64': 0.32.0
+      '@effect/tsgo-win32-x64': 0.32.0
 
   '@effect/vitest@4.0.0-beta.102(effect@4.0.0-beta.102)(vitest@4.1.10)':
     dependencies:
@@ -3307,6 +3491,66 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.65.0
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
@@ -4123,7 +4367,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  madge@8.0.0(typescript@6.0.3):
+  madge@8.0.0(typescript@7.0.2):
     dependencies:
       chalk: 4.1.2
       commander: 7.2.0
@@ -4138,7 +4382,7 @@ snapshots:
       ts-graphviz: 2.1.6
       walkdir: 0.4.1
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4675,9 +4919,9 @@ snapshots:
       '@ts-morph/common': 0.28.1
       code-block-writer: 13.0.3
 
-  tsconfck@3.1.6(typescript@6.0.3):
+  tsconfck@3.1.6(typescript@7.0.2):
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -4698,7 +4942,28 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  typescript@6.0.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   undici-types@7.24.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,12 +15,12 @@ allowBuilds:
     msgpackr-extract: true
 
 overrides:
-    "@effect/docgen>typescript": "6.0.3"
-    "madge>typescript": "6.0.3"
+    "@effect/docgen>typescript": "7.0.2"
+    "madge>typescript": "7.0.2"
 
 peerDependencyRules:
     allowedVersions:
-        typescript: "6.0.3"
+        typescript: "7.0.2"
 
 minimumReleaseAgeExclude:
     - effect-schemas

--- a/renovate.json
+++ b/renovate.json
@@ -54,26 +54,13 @@
         },
         {
             "description": "Group all Effect-TS packages into one PR",
-            "matchPackageNames": [
-                "effect",
-                "effect-schemas",
-                "/^@effect//",
-                "!@effect/build-utils",
-                "!@effect/language-service"
-            ],
+            "matchPackageNames": ["effect", "effect-schemas", "/^@effect//", "!@effect/build-utils", "!@effect/tsgo"],
             "groupName": "Effect-TS packages",
             "addLabels": ["pnpm"]
         },
         {
             "description": "Group build tools packages into one PR",
-            "matchPackageNames": [
-                "oxfmt",
-                "oxlint",
-                "@effect/build-utils",
-                "@effect/language-service",
-                "typescript",
-                "tsx"
-            ],
+            "matchPackageNames": ["oxfmt", "oxlint", "@effect/build-utils", "@effect/tsgo", "typescript", "tsx"],
             "groupName": "build tools packages",
             "addLabels": ["pnpm"]
         },


### PR DESCRIPTION
Swaps `@effect/language-service` for [`@effect/tsgo`](https://github.com/Effect-TS/tsgo#lsp-based-linter), which bundles the Effect language service on top of the native TypeScript 7 compiler. This is what enables the LSP-based linter.

Same change as leonitousconforti/eftar#47 and leonitousconforti/effect-schemas#49.

## Changes

- `typescript` 6.0.3 to 7.0.2
- `@effect/language-service` 0.87.1 replaced by `@effect/tsgo` 0.32.0 (it ships the language service, so the standalone package is no longer needed, matching the Effect monorepo)
- `prepare` now runs `effect-tsgo patch`, which patches the native `tsc` binary instead of the old JS `typescript.js` patch
- Bumped the `@effect/docgen` and `madge` typescript peer allowances to 7.0.2
- Grouped `@effect/tsgo` with the build tools in renovate, and excluded it from the Effect-TS group so it is not bumped alongside `effect` betas

`tsc --version` now reports `7.0.2+effect-tsgo.0.32.0`, and `pnpm check` surfaces Effect diagnostics inline, e.g. `TS377098` on `src/InternetSchemas.ts` and `TS377037` on `src/internal/circular.ts`. These are suggestion level, so they do not affect the exit code.

There is no `transform` plugin option in this repo's tsconfig, so unlike the other two repos nothing had to be removed there.

## Verification

Run locally: `pnpm check`, `pnpm lint`, `pnpm circular` all pass, and the TypeScript half of the build (`tsc -b tsconfig.build.json && pnpm babel`) compiles all 16 files.

I could not run `pnpm build` end to end locally because it also runs `build-submodules`, and the git submodules are not initialized in my checkout. That step is unrelated to this change and CI initializes them, so it should be covered there.

## Notes

- `@effect/tsgo` 0.32.0 rather than the newest 0.33.0, so it clears pnpm's default `minimumReleaseAge` of 1440 minutes without needing a `minimumReleaseAgeExclude` entry.
- `@effect/docgen` and `madge` declare `typescript` peers that predate 7.x, but neither uses the compiler JS API (docgen parses via ts-morph and spawns the `tsc` CLI), so both work unchanged.