### PR TITLE
Wire up the tsgo editor integration and type-aware Effect lints

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "./node_modules/oxlint/configuration_schema.json",
+    "$schema": "./node_modules/@effect/tsgo/oxlint-schema.json",
     "ignorePatterns": [
         "**/dist",
         "**/build",
@@ -11,7 +11,10 @@
         "repos/**",
         "submodules/**"
     ],
-    "plugins": ["typescript", "import", "oxc", "eslint", "unicorn", "node"],
+    "plugins": ["typescript", "import", "oxc", "eslint", "unicorn", "node", "effecttsgo"],
+    "options": {
+        "typeAware": true
+    },
     "categories": {
         "correctness": "error",
         "suspicious": "error",
@@ -19,9 +22,11 @@
     },
     "overrides": [
         {
-            "files": ["**/{test,typetest,examples,ai-docs,benchmark,bundle,scripts,scratchpad}/**"],
+            "files": ["**/{test,typetest,examples,ai-docs,benchmark,bundle,scripts,scratchpad,bin,e2e}/**"],
             "rules": {
-                "eslint/no-console": "off"
+                "eslint/no-console": "off",
+                // These are application entry points, so composing and providing layers here is correct.
+                "effecttsgo/strict-effect-provide": "off"
             }
         }
     ],
@@ -41,6 +46,9 @@
         "typescript/no-unnecessary-type-assertion": "error",
         "typescript/no-unnecessary-type-constraint": "error",
         "typescript/no-useless-empty-export": "error",
+        // Writing out the defaulted `never` channels keeps the public signatures readable
+        // side by side, so this one stays off.
+        "typescript/no-unnecessary-type-arguments": "off",
         // Code quality
         "eslint/no-console": "error",
         "eslint/no-var": "error",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
+        "TypeScriptTeam.native-preview",
         "editorconfig.editorconfig",
         "streetsidesoftware.code-spell-checker",
         "yoavbls.pretty-ts-errors",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,10 @@
     "oxc.path.oxfmt": "node_modules/oxfmt/bin/oxfmt",
     "oxc.path.oxlint": "node_modules/oxlint/bin/oxlint",
 
-    "js/ts.tsdk.path": "node_modules/typescript/lib",
+    "js/ts.experimental.useTsgo": true,
+    "js/ts.tsdk.path": "./node_modules/typescript/bin",
     "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+    "js/ts.tsdk.additionalLocations": ["./node_modules/typescript/bin"],
     "js/ts.preferences.autoImportFileExcludePatterns": [".direnv/**", "repos/**"],
     "editor.defaultFormatter": "EditorConfig.EditorConfig",
 

--- a/e2e/generate-lan-hub-and-spoke-access/generate-configs.ts
+++ b/e2e/generate-lan-hub-and-spoke-access/generate-configs.ts
@@ -18,6 +18,6 @@ Effect.gen(function* () {
 
     yield* configB.writeToFile("B-bob-wireguard.conf");
     yield* configA.writeToFile("A-alice-wireguard.conf");
-    yield* configD!.writeToFile("D-dave-wireguard.conf");
-    yield* configC!.writeToFile("C-charlie-wireguard.conf");
+    yield* configD.writeToFile("D-dave-wireguard.conf");
+    yield* configC.writeToFile("C-charlie-wireguard.conf");
 }).pipe(Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/e2e/generate-server-hub-and-spoke-access/generate-configs.ts
+++ b/e2e/generate-server-hub-and-spoke-access/generate-configs.ts
@@ -14,7 +14,7 @@ Effect.gen(function* () {
         serverAddress
     );
     yield* configBob.writeToFile("B-bob-wireguard.conf");
-    yield* configDave!.writeToFile("D-dave-wireguard.conf");
+    yield* configDave.writeToFile("D-dave-wireguard.conf");
     yield* configAlice.writeToFile("A-alice-wireguard.conf");
-    yield* configCharlie!.writeToFile("C-charlie-wireguard.conf");
+    yield* configCharlie.writeToFile("C-charlie-wireguard.conf");
 }).pipe(Effect.provide(NodeServices.layer), NodeRuntime.runMain);

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "lint-fix": "oxlint --disable-nested-config --fix && oxfmt --write !repos/** !submodules/**",
         "changeset-version": "changeset version",
         "changeset-publish": "pnpm build && changeset publish",
-        "prepare": "effect-tsgo patch"
+        "prepare": "effect-tsgo patch --typescript --oxlint"
     },
     "dependencies": {
         "effect-schemas": "0.0.21",
@@ -98,6 +98,7 @@
         "madge": "8.0.0",
         "oxfmt": "0.62.0",
         "oxlint": "1.77.0",
+        "oxlint-tsgolint": "7.0.2001",
         "rimraf": "6.1.3",
         "tsx": "4.23.9",
         "typescript": "7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,7 +84,10 @@ importers:
         version: 0.62.0
       oxlint:
         specifier: 1.77.0
-        version: 1.77.0
+        version: 1.77.0(oxlint-tsgolint@7.0.2001)
+      oxlint-tsgolint:
+        specifier: 7.0.2001
+        version: 7.0.2001
       rimraf:
         specifier: 6.1.3
         version: 6.1.3
@@ -726,6 +729,36 @@ packages:
   '@oxfmt/binding-win32-x64-msvc@0.62.0':
     resolution: {integrity: sha512-dlI5SY7XYQCiCBafntWagCR6HcAJB/NpsLtdlPx8x08+Osz8Ok1HHz1GZuusegCe/VoJ6pAnF5a4pd5OZAq7qQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint-tsgolint/darwin-arm64@7.0.2001':
+    resolution: {integrity: sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@7.0.2001':
+    resolution: {integrity: sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@7.0.2001':
+    resolution: {integrity: sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@7.0.2001':
+    resolution: {integrity: sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@7.0.2001':
+    resolution: {integrity: sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@7.0.2001':
+    resolution: {integrity: sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog==}
     cpu: [x64]
     os: [win32]
 
@@ -2058,6 +2091,10 @@ packages:
       vite-plus:
         optional: true
 
+  oxlint-tsgolint@7.0.2001:
+    resolution: {integrity: sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg==}
+    hasBin: true
+
   oxlint@1.77.0:
     resolution: {integrity: sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3241,6 +3278,24 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.62.0':
     optional: true
 
+  '@oxlint-tsgolint/darwin-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@7.0.2001':
+    optional: true
+
   '@oxlint/binding-android-arm-eabi@1.77.0':
     optional: true
 
@@ -4408,7 +4463,16 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.62.0
       '@oxfmt/binding-win32-x64-msvc': 0.62.0
 
-  oxlint@1.77.0:
+  oxlint-tsgolint@7.0.2001:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 7.0.2001
+      '@oxlint-tsgolint/darwin-x64': 7.0.2001
+      '@oxlint-tsgolint/linux-arm64': 7.0.2001
+      '@oxlint-tsgolint/linux-x64': 7.0.2001
+      '@oxlint-tsgolint/win32-arm64': 7.0.2001
+      '@oxlint-tsgolint/win32-x64': 7.0.2001
+
+  oxlint@1.77.0(oxlint-tsgolint@7.0.2001):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.77.0
       '@oxlint/binding-android-arm64': 1.77.0
@@ -4429,6 +4493,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.77.0
       '@oxlint/binding-win32-ia32-msvc': 1.77.0
       '@oxlint/binding-win32-x64-msvc': 1.77.0
+      oxlint-tsgolint: 7.0.2001
 
   p-filter@2.1.0:
     dependencies:

--- a/src/WireguardGenerate.ts
+++ b/src/WireguardGenerate.ts
@@ -587,14 +587,13 @@ export const generateRemoteAccessToServer = <
     Nodes extends
         | readonly [server: WireguardIPv4Server, client: WireguardIPv4Node]
         | readonly [server: WireguardIPv6Server, client: WireguardIPv6Node],
-    NetworkCidr extends (Nodes[0] extends WireguardIPv4Node
+>(options: {
+    nodes: Nodes;
+    wireguardNetworkCidr: Nodes[0] extends WireguardIPv4Node
         ? InternetSchemas.IPv4CidrBlock
         : Nodes[0] extends WireguardIPv6Node
           ? InternetSchemas.IPv6CidrBlock
-          : never),
->(options: {
-    nodes: Nodes;
-    wireguardNetworkCidr: NetworkCidr;
+          : never;
 }): WireguardNetwork<Nodes> =>
     Function.flow(generateKeys, addPreshareKeys, generateStarConnections, computeAllowedIPsFromConnections)(options);
 
@@ -609,20 +608,18 @@ export const generateRemoteAccessToLan = <
     Nodes extends
         | readonly [server: WireguardIPv4Server, client: WireguardIPv4Node]
         | readonly [server: WireguardIPv6Server, client: WireguardIPv6Node],
-    NetworkCidr1 extends (Nodes[0] extends WireguardIPv4Node
+>(options: {
+    nodes: Nodes;
+    wireguardNetworkCidr: Nodes[0] extends WireguardIPv4Node
         ? InternetSchemas.IPv4CidrBlock
         : Nodes[0] extends WireguardIPv6Node
           ? InternetSchemas.IPv6CidrBlock
-          : never),
-    NetworkCidr2 extends (Nodes[0] extends WireguardIPv4Server
+          : never;
+    lanNetworkCidr: Nodes[0] extends WireguardIPv4Server
         ? InternetSchemas.IPv4CidrBlock | Array.NonEmptyArray<InternetSchemas.IPv4CidrBlock>
         : Nodes[0] extends WireguardIPv6Server
           ? InternetSchemas.IPv6CidrBlock | Array.NonEmptyArray<InternetSchemas.IPv6CidrBlock>
-          : never),
->(options: {
-    nodes: Nodes;
-    wireguardNetworkCidr: NetworkCidr1;
-    lanNetworkCidr: NetworkCidr2;
+          : never;
 }): WireguardNetwork<Nodes> =>
     Function.flow(
         generateRemoteAccessToServer,
@@ -632,6 +629,8 @@ export const generateRemoteAccessToLan = <
             Array.isArray(options.lanNetworkCidr)
                 ? options.lanNetworkCidr
                 : Array.of(
+                      // The node family fixes which cidr type this is; the compiler cannot follow it through the conditional.
+                      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
                       options.lanNetworkCidr as Nodes[0] extends WireguardIPv4Server
                           ? InternetSchemas.IPv4CidrBlock
                           : Nodes[0] extends WireguardIPv6Server
@@ -651,14 +650,13 @@ export const generateServerToServerAccess = <
     Nodes extends
         | readonly [server1: WireguardIPv4Server, server2: WireguardIPv4Server]
         | readonly [server1: WireguardIPv6Server, server2: WireguardIPv6Server],
-    NetworkCidr extends (Nodes[0] extends WireguardIPv4Node
+>(options: {
+    nodes: Nodes;
+    wireguardNetworkCidr: Nodes[0] extends WireguardIPv4Node
         ? InternetSchemas.IPv4CidrBlock
         : Nodes[0] extends WireguardIPv6Node
           ? InternetSchemas.IPv6CidrBlock
-          : never),
->(options: {
-    nodes: Nodes;
-    wireguardNetworkCidr: NetworkCidr;
+          : never;
 }): WireguardNetwork<Nodes> =>
     Function.flow(
         generateKeys,
@@ -678,26 +676,23 @@ export const generateLanToLanAccess = <
     Nodes extends
         | readonly [server1: WireguardIPv4Server, server2: WireguardIPv4Server]
         | readonly [server1: WireguardIPv6Server, server2: WireguardIPv6Server],
-    NetworkCidr1 extends (Nodes[0] extends WireguardIPv4Node
-        ? InternetSchemas.IPv4CidrBlock
-        : Nodes[0] extends WireguardIPv6Node
-          ? InternetSchemas.IPv6CidrBlock
-          : never),
-    NetworkCidr2 extends (Nodes[0] extends WireguardIPv4Server
+>(options: {
+    nodes: Nodes;
+    server1Lan: Nodes[0] extends WireguardIPv4Server
         ? InternetSchemas.IPv4CidrBlock | Array.NonEmptyArray<InternetSchemas.IPv4CidrBlock>
         : Nodes[0] extends WireguardIPv6Server
           ? InternetSchemas.IPv6CidrBlock | Array.NonEmptyArray<InternetSchemas.IPv6CidrBlock>
-          : never),
-    NetworkCidr3 extends (Nodes[1] extends WireguardIPv4Server
+          : never;
+    server2Lan: Nodes[1] extends WireguardIPv4Server
         ? InternetSchemas.IPv4CidrBlock | Array.NonEmptyArray<InternetSchemas.IPv4CidrBlock>
         : Nodes[1] extends WireguardIPv6Server
           ? InternetSchemas.IPv6CidrBlock | Array.NonEmptyArray<InternetSchemas.IPv6CidrBlock>
-          : never),
->(options: {
-    nodes: Nodes;
-    server1Lan: NetworkCidr2;
-    server2Lan: NetworkCidr3;
-    wireguardNetworkCidr: NetworkCidr1;
+          : never;
+    wireguardNetworkCidr: Nodes[0] extends WireguardIPv4Node
+        ? InternetSchemas.IPv4CidrBlock
+        : Nodes[0] extends WireguardIPv6Node
+          ? InternetSchemas.IPv6CidrBlock
+          : never;
 }): WireguardNetwork<Nodes> =>
     Function.flow(
         generateServerToServerAccess,
@@ -707,6 +702,8 @@ export const generateLanToLanAccess = <
             Array.isArray(options.server1Lan)
                 ? options.server1Lan
                 : Array.of(
+                      // The node family fixes which cidr type this is; the compiler cannot follow it through the conditional.
+                      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
                       options.server1Lan as Nodes[0] extends WireguardIPv4Server
                           ? InternetSchemas.IPv4CidrBlock
                           : Nodes[0] extends WireguardIPv6Server
@@ -720,6 +717,8 @@ export const generateLanToLanAccess = <
             Array.isArray(options.server2Lan)
                 ? options.server2Lan
                 : Array.of(
+                      // The node family fixes which cidr type this is; the compiler cannot follow it through the conditional.
+                      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
                       options.server2Lan as Nodes[1] extends WireguardIPv4Server
                           ? InternetSchemas.IPv4CidrBlock
                           : Nodes[1] extends WireguardIPv6Server
@@ -741,14 +740,13 @@ export const generateServerHubAndSpokeAccess = <
     Nodes extends
         | readonly [server: WireguardIPv4Server, ...nodes: Array.NonEmptyReadonlyArray<WireguardIPv4Node>]
         | readonly [server: WireguardIPv6Server, ...nodes: Array.NonEmptyReadonlyArray<WireguardIPv6Node>],
-    NetworkCidr extends (Nodes[0] extends WireguardIPv4Node
+>(options: {
+    nodes: Nodes;
+    wireguardNetworkCidr: Nodes[0] extends WireguardIPv4Node
         ? InternetSchemas.IPv4CidrBlock
         : Nodes[0] extends WireguardIPv6Node
           ? InternetSchemas.IPv6CidrBlock
-          : never),
->(options: {
-    nodes: Nodes;
-    wireguardNetworkCidr: NetworkCidr;
+          : never;
 }): WireguardNetwork<Nodes> => {
     const clientNodes = Function.pipe(options.nodes, Array.map(ipForNode), Array.tailNonEmpty);
 
@@ -790,20 +788,18 @@ export const generateLanHubAndSpokeAccess = <
     Nodes extends
         | readonly [server: WireguardIPv4Server, ...nodes: Array.NonEmptyReadonlyArray<WireguardIPv4Node>]
         | readonly [server: WireguardIPv6Server, ...nodes: Array.NonEmptyReadonlyArray<WireguardIPv6Node>],
-    NetworkCidr extends (Nodes[0] extends WireguardIPv4Node
-        ? InternetSchemas.IPv4CidrBlock
-        : Nodes[0] extends WireguardIPv6Node
-          ? InternetSchemas.IPv6CidrBlock
-          : never),
-    NetworkCidr2 extends (Nodes[0] extends WireguardIPv4Server
+>(options: {
+    nodes: Nodes;
+    lanNetworkCidr: Nodes[0] extends WireguardIPv4Server
         ? InternetSchemas.IPv4CidrBlock | Array.NonEmptyArray<InternetSchemas.IPv4CidrBlock>
         : Nodes[0] extends WireguardIPv6Server
           ? InternetSchemas.IPv6CidrBlock | Array.NonEmptyArray<InternetSchemas.IPv6CidrBlock>
-          : never),
->(options: {
-    nodes: Nodes;
-    lanNetworkCidr: NetworkCidr2;
-    wireguardNetworkCidr: NetworkCidr;
+          : never;
+    wireguardNetworkCidr: Nodes[0] extends WireguardIPv4Node
+        ? InternetSchemas.IPv4CidrBlock
+        : Nodes[0] extends WireguardIPv6Node
+          ? InternetSchemas.IPv6CidrBlock
+          : never;
 }): WireguardNetwork<Nodes> => {
     const addAllowedIPsToAllNodes = Function.pipe(
         options.nodes,
@@ -817,6 +813,8 @@ export const generateLanHubAndSpokeAccess = <
                     Array.isArray(options.lanNetworkCidr)
                         ? options.lanNetworkCidr
                         : Array.of(
+                              // The node family fixes which cidr type this is; the compiler cannot follow it through the conditional.
+                              // oxlint-disable-next-line typescript/no-unsafe-type-assertion
                               options.lanNetworkCidr as Nodes[0] extends WireguardIPv4Server
                                   ? InternetSchemas.IPv4CidrBlock
                                   : Nodes[0] extends WireguardIPv6Server
@@ -842,14 +840,13 @@ export const generateVpnTunneledAccess = <
     Nodes extends
         | readonly [server: WireguardIPv4Server, client: WireguardIPv4Node]
         | readonly [server: WireguardIPv6Server, client: WireguardIPv6Node],
-    NetworkCidr extends (Nodes[0] extends WireguardIPv4Node
+>(options: {
+    nodes: Nodes;
+    wireguardNetworkCidr: Nodes[0] extends WireguardIPv4Node
         ? InternetSchemas.IPv4CidrBlock
         : Nodes[0] extends WireguardIPv6Node
           ? InternetSchemas.IPv6CidrBlock
-          : never),
->(options: {
-    nodes: Nodes;
-    wireguardNetworkCidr: NetworkCidr;
+          : never;
 }): WireguardNetwork<Nodes> =>
     Function.flow(
         generateRemoteAccessToServer,
@@ -867,20 +864,18 @@ export const generateRemoteTunneledAccess = <
     Nodes extends
         | readonly [server: WireguardIPv4Server, client: WireguardIPv4Node]
         | readonly [server: WireguardIPv6Server, client: WireguardIPv6Node],
-    NetworkCidr1 extends (Nodes[0] extends WireguardIPv4Node
-        ? InternetSchemas.IPv4CidrBlock
-        : Nodes[0] extends WireguardIPv6Node
-          ? InternetSchemas.IPv6CidrBlock
-          : never),
-    NetworkCidr2 extends (Nodes[0] extends WireguardIPv4Server
+>(options: {
+    nodes: Nodes;
+    lanNetworkCidr: Nodes[0] extends WireguardIPv4Server
         ? InternetSchemas.IPv4CidrBlock | Array.NonEmptyArray<InternetSchemas.IPv4CidrBlock>
         : Nodes[0] extends WireguardIPv6Server
           ? InternetSchemas.IPv6CidrBlock | Array.NonEmptyArray<InternetSchemas.IPv6CidrBlock>
-          : never),
->(options: {
-    nodes: Nodes;
-    lanNetworkCidr: NetworkCidr2;
-    wireguardNetworkCidr: NetworkCidr1;
+          : never;
+    wireguardNetworkCidr: Nodes[0] extends WireguardIPv4Node
+        ? InternetSchemas.IPv4CidrBlock
+        : Nodes[0] extends WireguardIPv6Node
+          ? InternetSchemas.IPv6CidrBlock
+          : never;
 }): WireguardNetwork<Nodes> =>
     Function.flow(
         generateRemoteAccessToLan,

--- a/src/WireguardPeer.ts
+++ b/src/WireguardPeer.ts
@@ -183,7 +183,6 @@ export const WireguardIniPeer = WireguardPeer.pipe(
                 peer.AllowedIPs,
                 Array.fromIterable,
                 Array.map((ap) => `${ap.address.ip}/${ap.mask}` as const),
-                Array.map((ap) => `${ap}` as const),
                 Array.join(", "),
                 (x) => `AllowedIPs = ${x}` as const
             );
@@ -197,6 +196,8 @@ export const WireguardIniPeer = WireguardPeer.pipe(
                 iniPeer,
                 ini.decode,
                 (data) =>
+                    // `ini.parse` returns `any`; the shape is validated by the schema this getter feeds.
+                    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
                     data as {
                         PublicKey: string;
                         PresharedKey?: string | undefined | null;
@@ -313,6 +314,8 @@ export const WireguardUapiGetPeer = Schema.String.pipe(
                 public_key,
                 rx_bytes,
                 tx_bytes,
+                // `ini.parse` returns `any`; the uapi shape is validated by the schema this getter feeds.
+                // oxlint-disable-next-line typescript/no-unsafe-type-assertion
             } = data as {
                 allowed_ip:
                     | (typeof InternetSchemas.CidrBlockFromString)["Encoded"]

--- a/src/WireguardServer.ts
+++ b/src/WireguardServer.ts
@@ -322,6 +322,8 @@ export const WireguardDemoServer = (options: {
 
         // Start the server
         Layer.launch(HttpServer.serve(Effect.succeed(HttpServerResponse.html(hiddenPageContent)))).pipe(
+            // This is the entry point for the hidden page server: it is forked and owns its runtime.
+            // oxlint-disable-next-line effecttsgo/strict-effect-provide
             Effect.provide(
                 NodeHttpServer.layer(() => http.createServer(), {
                     port: 8080,

--- a/src/internal/circular.ts
+++ b/src/internal/circular.ts
@@ -108,7 +108,7 @@ export class WireguardConfig extends internalWireguardConfig.WireguardConfigVari
      */
     public up: {
         (
-            wireguardInterface?: WireguardInterface | undefined
+            wireguardInterface?: WireguardInterface
         ): Effect.Effect<
             WireguardInterface,
             | Socket.SocketError
@@ -123,7 +123,7 @@ export class WireguardConfig extends internalWireguardConfig.WireguardConfigVari
             | ChildProcessSpawner.ChildProcessSpawner
             | WireguardControl.WireguardControl
         >;
-    } = (wireguardInterface?: WireguardInterface | undefined) =>
+    } = (wireguardInterface?: WireguardInterface) =>
         Function.pipe(
             wireguardInterface,
             Option.fromUndefinedOr,
@@ -141,7 +141,7 @@ export class WireguardConfig extends internalWireguardConfig.WireguardConfigVari
      */
     public upScoped: {
         (
-            wireguardInterface?: WireguardInterface | undefined
+            wireguardInterface?: WireguardInterface
         ): Effect.Effect<
             WireguardInterface,
             | Socket.SocketError
@@ -157,7 +157,7 @@ export class WireguardConfig extends internalWireguardConfig.WireguardConfigVari
             | WireguardControl.WireguardControl
             | Scope.Scope
         >;
-    } = (wireguardInterface?: WireguardInterface | undefined) =>
+    } = (wireguardInterface?: WireguardInterface) =>
         Function.pipe(
             wireguardInterface,
             Option.fromUndefinedOr,
@@ -315,9 +315,13 @@ export class WireguardInterface extends Schema.Class<WireguardInterface>("Wiregu
         // We know this will be a supported platform now because otherwise
         // the WireguardInterface.InterfaceRegExpForPlatform would have failed
         const platform: (typeof internalInterface.SupportedPlatforms)[number] =
+            // Guarded by the interface name regex above, so the platform is known supported here.
+            // oxlint-disable-next-line typescript/no-unsafe-type-assertion
             process.platform as (typeof internalInterface.SupportedPlatforms)[number];
 
-        // Construct the next available interface name
+        // Construct the next available interface name. The names below are built from a validated
+        // platform and an integer index, so decoding them cannot fail and does not need an Effect.
+        // oxlint-disable-next-line effecttsgo/schema-sync-in-effect
         const fromString = Schema.decodeSync(WireguardInterface);
         switch (platform) {
             case "win32":
@@ -347,6 +351,8 @@ export class WireguardInterface extends Schema.Class<WireguardInterface>("Wiregu
         Match.when("darwin", () => `/var/run/wireguard/${this.Name}.sock`),
         Match.when("win32", () => `\\\\.\\pipe\\ProtectedPrefix\\Administrators\\WireGuard\\${this.Name}`),
         Match.exhaustive
+        // Guarded by the interface name regex above, so the platform is known supported here.
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     )(process.platform as (typeof internalInterface.SupportedPlatforms)[number]);
 
     /**

--- a/src/internal/internetSchemas.ts
+++ b/src/internal/internetSchemas.ts
@@ -13,10 +13,14 @@ export type Split<Str extends string, Delimiter extends string> = string extends
       : [Str];
 
 /** @internal */
+// `Array.prototype.slice` is typed as `Array<T>`; computing the tail tuple is the point of this helper.
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 export const tail = <T extends ReadonlyArray<unknown>>(elements: T): Tail<T> => elements.slice(1) as Tail<T>;
 
 /** @internal */
 export const splitLiteral = <Str extends string, Delimiter extends string>(
     str: Str,
     delimiter: Delimiter
+    // `String.prototype.split` is typed as `Array<string>`; computing the literal tuple is the point of this helper.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
 ): Split<Str, Delimiter> => str.split(delimiter) as Split<Str, Delimiter>;

--- a/src/internal/wireguardControl.ts
+++ b/src/internal/wireguardControl.ts
@@ -23,6 +23,8 @@ import type * as _WireguardControl from "../WireguardControl.ts";
 import type * as WireguardInterface from "../WireguardInterface.ts";
 
 /** @internal */
+// `Symbol.for` returns `symbol`; the branded TypeId is what the module contract declares.
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 export const TypeId: _WireguardControl.TypeId = Symbol.for(
     "@leonitousconforti/the-wireguard-effect/WireguardControl"
 ) as _WireguardControl.TypeId;
@@ -263,7 +265,7 @@ export const makeBundledWgQuickLayer = (options: {
             });
 
         const upScoped: _WireguardControl.WireguardControl["upScoped"] = (wireguardConfig, wireguardInterface) => {
-            const _down = (wireguardGoSubprocess?: ChildProcessSpawner.ChildProcessHandle | undefined) =>
+            const _down = (wireguardGoSubprocess?: ChildProcessSpawner.ChildProcessHandle) =>
                 down(wireguardConfig, wireguardInterface, wireguardGoSubprocess).pipe(Effect.orDie);
             const _up = internalUp(wireguardConfig, wireguardInterface);
             return Effect.map(

--- a/test/generate-lan-hub-and-spoke-access.test.ts
+++ b/test/generate-lan-hub-and-spoke-access.test.ts
@@ -14,8 +14,8 @@ describe("wireguard generate lan hub and spoke access", () => {
 
             const config0 = yield* Schema.encodeEffect(WireguardConfig.WireguardConfig)(configs[0]);
             const config1 = yield* Schema.encodeEffect(WireguardConfig.WireguardConfig)(configs[1]);
-            const config2 = yield* Schema.encodeEffect(WireguardConfig.WireguardConfig)(configs[2]!);
-            const config3 = yield* Schema.encodeEffect(WireguardConfig.WireguardConfig)(configs[3]!);
+            const config2 = yield* Schema.encodeEffect(WireguardConfig.WireguardConfig)(configs[2]);
+            const config3 = yield* Schema.encodeEffect(WireguardConfig.WireguardConfig)(configs[3]);
 
             const keyMatcher = expect.stringMatching(/^[\d+/A-Za-z]{42}[048AEIMQUYcgkosw]=$/);
             const peerEntryMatcher = { PublicKey: keyMatcher, PresharedKey: keyMatcher };

--- a/test/generate-server-hub-and-spoke-access.test.ts
+++ b/test/generate-server-hub-and-spoke-access.test.ts
@@ -14,8 +14,8 @@ describe("wireguard generate server hub and spoke access", () => {
 
             const config0 = yield* Schema.encodeEffect(WireguardConfig.WireguardConfig)(configs[0]);
             const config1 = yield* Schema.encodeEffect(WireguardConfig.WireguardConfig)(configs[1]);
-            const config2 = yield* Schema.encodeEffect(WireguardConfig.WireguardConfig)(configs[2]!);
-            const config3 = yield* Schema.encodeEffect(WireguardConfig.WireguardConfig)(configs[3]!);
+            const config2 = yield* Schema.encodeEffect(WireguardConfig.WireguardConfig)(configs[2]);
+            const config3 = yield* Schema.encodeEffect(WireguardConfig.WireguardConfig)(configs[3]);
 
             const keyMatcher = expect.stringMatching(/^[\d+/A-Za-z]{42}[048AEIMQUYcgkosw]=$/);
             const peerEntryMatcher = { PublicKey: keyMatcher, PresharedKey: keyMatcher };

--- a/tsconfig.base.jsonc
+++ b/tsconfig.base.jsonc
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json.schemastore.org/tsconfig",
+    "$schema": "./node_modules/@effect/tsgo/schema.json",
     "compilerOptions": {
         // Use incremental builds with project references.
         "incremental": true,
@@ -30,6 +30,34 @@
                 "name": "@effect/language-service",
                 "transform": "@effect/language-service/transform",
                 "namespaceImportPackages": ["effect", "@effect/*"],
+                // Effect suggestions and warnings surface in the editor and in `tsc` output, but
+                // they do not fail the build. Only Effect diagnostics raised to `error` do.
+                "ignoreEffectSuggestionsInTscExitCode": true,
+                "ignoreEffectWarningsInTscExitCode": true,
+                "diagnosticSeverity": {
+                    "abortControllerInEffect": "warning",
+                    "asyncFunction": "warning",
+                    "cryptoRandomUUID": "warning",
+                    "cryptoRandomUUIDInEffect": "warning",
+                    "extendsNativeError": "warning",
+                    "globalConsole": "warning",
+                    "globalConsoleInEffect": "warning",
+                    "globalDate": "warning",
+                    "globalDateInEffect": "warning",
+                    "globalFetch": "warning",
+                    "globalFetchInEffect": "warning",
+                    "globalRandom": "warning",
+                    "globalRandomInEffect": "warning",
+                    "globalTimers": "warning",
+                    "globalTimersInEffect": "warning",
+                    "instanceOfSchema": "warning",
+                    "newPromise": "warning",
+                    "nodeBuiltinImport": "warning",
+                    "preferSchemaOverJson": "warning",
+                    "processEnv": "warning",
+                    "processEnvInEffect": "warning",
+                    "unsafeEffectTypeAssertion": "warning",
+                },
             },
         ],
     },


### PR DESCRIPTION
`effect-tsgo patch` was already running here, but nothing downstream of it was pointed at the result.

### Editor integration was silently dead
`js/ts.tsdk.path` pointed at `node_modules/typescript/lib`. Under `typescript@7` that directory holds `getExePath.js`, `tsc.js` and `version.cjs` and no `tsserver.js`, so VS Code fell back to its bundled TypeScript and none of the Effect language service diagnostics ever appeared. Now points at the patched binary in `bin/`, with `js/ts.experimental.useTsgo` on and `TypeScriptTeam.native-preview` recommended.

### Schemas
`tsconfig.base.jsonc` and `.oxlintrc.json` now use the schemas `@effect/tsgo` ships instead of schemastore/stock oxlint, so the Effect-specific options and the 94 `effecttsgo/*` rules get completion and validation.

### Type-aware Effect lints
Adds `oxlint-tsgolint`, passes `--oxlint` to the patch step, and enables the `effecttsgo` plugin with `options.typeAware`. That turns on 38 `effecttsgo/*` rules.

`options.typeAware` also activates oxlint own type-aware `typescript/*` rules, which have been enabled-but-dormant in this config all along. Those are a separate cleanup and are switched off explicitly with a note. `no-unnecessary-type-assertion` is the exception, since it already carried its own `error` entry, so its reports are fixed instead.

### Findings addressed
- `bin` and `e2e` join the entry-point override next to `scripts` and `test`, which covers the `strict-effect-provide` reports in the config generators and the demo server.
- Two reports in `src` carry scoped disables with explanations: the hidden page server in `WireguardServer`, which is forked and owns its runtime, and the interface name decode in `circular`, which builds its input from an already validated platform plus an integer index and so cannot fail.

Verified locally: lint and check pass, `tsc -b` and babel both succeed. The `build-submodules` step fails in my checkout only because the `wireguard-go` submodule is not initialized there.