### PR TITLE
Enable Renovate branch automerge for devDependency updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "renovate/**"]
   pull_request:
     branches: ["main"]
   # schedule:

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
         "helpers:pinGitHubActionDigests"
     ],
     "labels": ["dependencies", "renovate"],
+    "automergeType": "branch",
     "ignorePaths": ["**/node_modules/**", "repos/effect/**", "repos/effect-smol/**"],
     "enabledManagers": ["github-actions", "nix", "git-submodules", "pip_requirements", "npm"],
     "git-submodules": {
@@ -85,6 +86,17 @@
             "description": "Keep the Nix flake inputs (flake.lock) current",
             "matchManagers": ["nix"],
             "addLabels": ["nix"]
+        },
+        {
+            "description": "Automerge minor and patch devDependency updates once CI passes on the update branch",
+            "matchDepTypes": ["devDependencies"],
+            "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+            "automerge": true
+        },
+        {
+            "description": "Never automerge typescript since minor releases can contain breaking changes",
+            "matchPackageNames": ["typescript"],
+            "automerge": false
         }
     ]
 }


### PR DESCRIPTION
Supports `automergeType: "branch"` so Renovate can merge passing devDependency updates without opening a PR.

- Run CI on pushes to `renovate/**` branches, since branch automerge never opens a PR and the current triggers only cover `main` pushes and PRs. Without this, Renovate would treat the branch as having no checks and merge untested.
- Set `automergeType: "branch"` in renovate.json.
- Automerge minor, patch, pin, and digest updates to devDependencies once CI passes.
- Exclude `typescript` from automerge since its minor releases can contain breaking changes.