### PR TITLE
Add changeset for type-aware lint cleanups

### DIFF
--- a/.changeset/tough-lemons-relate.md
+++ b/.changeset/tough-lemons-relate.md
@@ -1,0 +1,5 @@
+---
+"the-wireguard-effect": patch
+---
+
+Code cleanups in WireguardGenerate, WireguardPeer, and internal modules from enabling the type-aware Effect lints. No intended behavior changes.


### PR DESCRIPTION
Adds a patch changeset covering the src cleanups from #382 so they get released.