### PR TITLE
Fix remaining type-aware Effect lint diagnostics

### DIFF
--- a/.changeset/spicy-pandas-behave.md
+++ b/.changeset/spicy-pandas-behave.md
@@ -1,0 +1,5 @@
+---
+"the-wireguard-effect": patch
+---
+
+Fix the remaining type-aware Effect lint diagnostics: use `Schema.Finite` and `Schema.FiniteFromString` for port, byte counter, and firewall mark schemas, and drop an unnecessary `Effect.sync` wrapper in WireguardGenerate. No intended behavior changes.

--- a/src/InternetSchemas.ts
+++ b/src/InternetSchemas.ts
@@ -60,10 +60,10 @@ export const DurationFromSeconds = Schema.Int.pipe(
  *     ```;
  */
 export const IPv4Endpoint = Schema.Union([
-    Schema.Struct({ ip: Schema.String, port: Schema.Number, family: IPv4Family }),
-    Schema.Struct({ ip: Schema.String, natPort: Schema.Number, listenPort: Schema.Number, family: IPv4Family }),
-    Schema.TemplateLiteral([Schema.String, Schema.Literal(":"), Schema.Number]),
-    Schema.TemplateLiteral([Schema.String, Schema.Literal(":"), Schema.Number, Schema.Literal(":"), Schema.Number]),
+    Schema.Struct({ ip: Schema.String, port: Schema.Finite, family: IPv4Family }),
+    Schema.Struct({ ip: Schema.String, natPort: Schema.Finite, listenPort: Schema.Finite, family: IPv4Family }),
+    Schema.TemplateLiteral([Schema.String, Schema.Literal(":"), Schema.Finite]),
+    Schema.TemplateLiteral([Schema.String, Schema.Literal(":"), Schema.Finite, Schema.Literal(":"), Schema.Finite]),
 ]).pipe(
     Schema.decodeTo(Schema.Struct({ address: IPv4, natPort: Port, listenPort: Port }), {
         decode: SchemaGetter.transform((data) => {
@@ -130,23 +130,23 @@ export const IPv4Endpoint = Schema.Union([
  *     ```;
  */
 export const IPv6Endpoint = Schema.Union([
-    Schema.Struct({ ip: Schema.String, port: Schema.Number, family: IPv6Family }),
-    Schema.Struct({ ip: Schema.String, natPort: Schema.Number, listenPort: Schema.Number, family: IPv6Family }),
+    Schema.Struct({ ip: Schema.String, port: Schema.Finite, family: IPv6Family }),
+    Schema.Struct({ ip: Schema.String, natPort: Schema.Finite, listenPort: Schema.Finite, family: IPv6Family }),
     Schema.TemplateLiteral([
         Schema.Literal("["),
         Schema.String,
         Schema.Literal("]"),
         Schema.Literal(":"),
-        Schema.Number,
+        Schema.Finite,
     ]),
     Schema.TemplateLiteral([
         Schema.Literal("["),
         Schema.String,
         Schema.Literal("]"),
         Schema.Literal(":"),
-        Schema.Number,
+        Schema.Finite,
         Schema.Literal(":"),
-        Schema.Number,
+        Schema.Finite,
     ]),
 ]).pipe(
     Schema.decodeTo(Schema.Struct({ address: IPv6, natPort: Port, listenPort: Port }), {
@@ -188,10 +188,10 @@ export const IPv6Endpoint = Schema.Union([
  * @category Schemas
  */
 export const HostnameEndpoint = Schema.Union([
-    Schema.Struct({ host: Schema.String, port: Schema.Number }),
-    Schema.Struct({ host: Schema.String, natPort: Schema.Number, listenPort: Schema.Number }),
-    Schema.TemplateLiteral([Schema.String, Schema.Literal(":"), Schema.Number]),
-    Schema.TemplateLiteral([Schema.String, Schema.Literal(":"), Schema.Number, Schema.Literal(":"), Schema.Number]),
+    Schema.Struct({ host: Schema.String, port: Schema.Finite }),
+    Schema.Struct({ host: Schema.String, natPort: Schema.Finite, listenPort: Schema.Finite }),
+    Schema.TemplateLiteral([Schema.String, Schema.Literal(":"), Schema.Finite]),
+    Schema.TemplateLiteral([Schema.String, Schema.Literal(":"), Schema.Finite, Schema.Literal(":"), Schema.Finite]),
 ]).pipe(
     Schema.decodeTo(Schema.Struct({ host: Schema.String, natPort: Port, listenPort: Port }), {
         decode: SchemaGetter.transform((data) => {

--- a/src/WireguardGenerate.ts
+++ b/src/WireguardGenerate.ts
@@ -506,11 +506,11 @@ export const toConfigs = <
                 const keysForNode = Record.get(keys, ipForNode(node)).pipe(Option.getOrThrow);
                 const endpointForNode = Record.get(endpointsByIp, ipForNode(node)).pipe(Option.getOrThrow);
 
-                const endpointForNodeEncoded = yield* Schema.is(WireguardInternetSchemas.SetupData)(endpointForNode)
-                    ? Schema.encodeEffect(WireguardInternetSchemas.SetupData)(endpointForNode).pipe(
+                const endpointForNodeEncoded = Schema.is(WireguardInternetSchemas.SetupData)(endpointForNode)
+                    ? yield* Schema.encodeEffect(WireguardInternetSchemas.SetupData)(endpointForNode).pipe(
                           Effect.map((x) => x[0])
                       )
-                    : Effect.sync(() => undefined);
+                    : undefined;
 
                 const address = Schema.is(WireguardInternetSchemas.SetupData)(endpointForNode)
                     ? endpointForNode[1].ip

--- a/src/WireguardPeer.ts
+++ b/src/WireguardPeer.ts
@@ -93,10 +93,10 @@ export class WireguardPeer extends internalWireguardPeer.WireguardPeerConfigVari
     PresharedKey: WireguardKey.WireguardKey.pipe(Schema.OptionFromOptionalNullOr),
 
     /** The number of received bytes. */
-    rxBytes: internalWireguardPeer.WireguardPeerConfigVariantSchema.FieldOnly(["uapi"])(Schema.NumberFromString),
+    rxBytes: internalWireguardPeer.WireguardPeerConfigVariantSchema.FieldOnly(["uapi"])(Schema.FiniteFromString),
 
     /** The number of transmitted bytes. */
-    txBytes: internalWireguardPeer.WireguardPeerConfigVariantSchema.FieldOnly(["uapi"])(Schema.NumberFromString),
+    txBytes: internalWireguardPeer.WireguardPeerConfigVariantSchema.FieldOnly(["uapi"])(Schema.FiniteFromString),
 
     /**
      * The number of seconds since the most recent handshake, expressed relative
@@ -104,7 +104,7 @@ export class WireguardPeer extends internalWireguardPeer.WireguardPeerConfigVari
      */
     lastHandshake: internalWireguardPeer.WireguardPeerConfigVariantSchema.FieldOnly(["uapi"])(
         Function.pipe(
-            Schema.NumberFromString,
+            Schema.FiniteFromString,
             Schema.decode({
                 decode: SchemaGetter.passthrough(),
                 encode: SchemaGetter.transform(Number.multiply(1000)),

--- a/src/WireguardServer.ts
+++ b/src/WireguardServer.ts
@@ -31,6 +31,8 @@ import * as Socket from "effect/unstable/socket/Socket";
 import * as SocketServer from "effect/unstable/socket/SocketServer";
 
 import * as dns from "node:dns";
+// The node http module is required here to construct the NodeHttpServer layer.
+// @effect-diagnostics-next-line nodeBuiltinImport:off
 import * as http from "node:http";
 
 import type * as WireguardInternetSchemas from "./InternetSchemas.ts";
@@ -56,7 +58,7 @@ export const WireguardDemoServerSchema = Schema.TemplateLiteral([
     Schema.Literal(":"),
     Schema.String,
     Schema.Literal(":"),
-    Schema.Number,
+    Schema.Finite,
     Schema.Literal(":"),
     Schema.String,
     Schema.Literal("\n"),

--- a/src/internal/circular.ts
+++ b/src/internal/circular.ts
@@ -54,7 +54,7 @@ export class WireguardConfig extends internalWireguardConfig.WireguardConfigVari
      */
     ListenPort: Schema.Union([
         InternetSchemas.Port,
-        Schema.NumberFromString.pipe(Schema.decodeTo(InternetSchemas.Port)),
+        Schema.FiniteFromString.pipe(Schema.decodeTo(InternetSchemas.Port)),
     ]),
 
     /**
@@ -62,7 +62,7 @@ export class WireguardConfig extends internalWireguardConfig.WireguardConfigVari
      * fwmark of the interface. The value may 0 in the case of a set operation,
      * in which case it indicates that the fwmark should be removed.
      */
-    FirewallMark: Schema.Number.pipe(Schema.NullOr, Schema.optional),
+    FirewallMark: Schema.Finite.pipe(Schema.NullOr, Schema.optional),
 
     /**
      * The value for this key should be a lowercase hex-encoded private key of
@@ -322,6 +322,7 @@ export class WireguardInterface extends Schema.Class<WireguardInterface>("Wiregu
         // Construct the next available interface name. The names below are built from a validated
         // platform and an integer index, so decoding them cannot fail and does not need an Effect.
         // oxlint-disable-next-line effecttsgo/schema-sync-in-effect
+        // @effect-diagnostics-next-line schemaSyncInEffect:off
         const fromString = Schema.decodeSync(WireguardInterface);
         switch (platform) {
             case "win32":


### PR DESCRIPTION
Fixes the remaining diagnostics reported by `tsc -b tsconfig.json` from the type-aware Effect lints. The build is now clean.

- `InternetSchemas`: use `Schema.Finite` for port fields and template literal segments in `IPv4Endpoint`, `IPv6Endpoint`, and `HostnameEndpoint`
- `WireguardPeer`: use `Schema.FiniteFromString` for `rxBytes`, `txBytes`, and `lastHandshake`
- `internal/circular`: use `Schema.FiniteFromString` for `ListenPort` and `Schema.Finite` for `FirewallMark`, plus a tsc-side suppression matching the existing oxlint suppression for `decodeSync` in a generator
- `WireguardServer`: use `Schema.Finite` in the demo server template literal, and suppress the `node:http` import warning since the import is required by `NodeHttpServer.layer`
- `WireguardGenerate`: move a `yield*` inside the ternary so the fallback branch is plain `undefined` instead of `Effect.sync(() => undefined)`

No intended behavior changes. `pnpm check`, `pnpm lint`, and the unit tests pass (the e2e test requires the prebuilt wireguard-go binaries and is unaffected).