### PR TITLE
chore: point oxc extension at native tsgolint binary

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "oxc.useExecPath": true,
     "oxc.path.oxfmt": "node_modules/oxfmt/bin/oxfmt",
     "oxc.path.oxlint": "node_modules/oxlint/bin/oxlint",
+    "oxc.path.tsgolint": "node_modules/oxlint-tsgolint/../@oxlint-tsgolint/darwin-arm64/tsgolint",
 
     "js/ts.experimental.useTsgo": true,
     "js/ts.tsdk.path": "./node_modules/typescript/bin",


### PR DESCRIPTION
Backports the `oxc.path.tsgolint` setting from tinyburg.

Without it the oxlint language server spawns the `tsgolint` pnpm shim, which ends in `exec node ...`. VS Code's extension host has no `node` on PATH under the nix-only toolchain, so every type-aware lint request fails with `exec: node: not found` in the Oxc (Lint) output channel. Pointing at the native binary skips node entirely.

This repo sets `options.typeAware: true` in `.oxlintrc.json`, so it is affected. The `..` in the path resolves through the pnpm symlink into the `.pnpm` dir, so it survives version bumps.